### PR TITLE
Adaptation to moving Dynamic Simulation Params to Dynamic Simulation server

### DIFF
--- a/src/main/java/org/gridsuite/dynamicsecurityanalysis/server/controller/DynamicSecurityAnalysisController.java
+++ b/src/main/java/org/gridsuite/dynamicsecurityanalysis/server/controller/DynamicSecurityAnalysisController.java
@@ -11,7 +11,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.apache.commons.collections4.CollectionUtils;
 import org.gridsuite.computation.dto.ReportInfos;
 import org.gridsuite.dynamicsecurityanalysis.server.dto.DynamicSecurityAnalysisStatus;
 import org.gridsuite.dynamicsecurityanalysis.server.service.DynamicSecurityAnalysisResultService;
@@ -92,12 +91,10 @@ public class DynamicSecurityAnalysisController {
 
     @PutMapping(value = "/results/invalidate-status", produces = "application/json")
     @Operation(summary = "Invalidate the dynamic security analysis status from the database")
-    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "The dynamic security analysis result uuids have been invalidated"),
-        @ApiResponse(responseCode = "404", description = "Dynamic security analysis result has not been found")})
-    public ResponseEntity<List<UUID>> invalidateStatus(@Parameter(description = "Result UUIDs") @RequestParam("resultUuid") List<UUID> resultUuids) {
-        List<UUID> result = dynamicSecurityAnalysisResultService.updateStatus(resultUuids, DynamicSecurityAnalysisStatus.NOT_DONE);
-        return CollectionUtils.isEmpty(result) ? ResponseEntity.notFound().build() :
-                ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(result);
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "The dynamic security analysis result uuids have been invalidated")})
+    public ResponseEntity<Void> invalidateStatus(@Parameter(description = "Result UUIDs") @RequestParam("resultUuid") List<UUID> resultUuids) {
+        dynamicSecurityAnalysisResultService.updateStatus(resultUuids, DynamicSecurityAnalysisStatus.NOT_DONE);
+        return ResponseEntity.ok().build();
     }
 
     @DeleteMapping(value = "/results/{resultUuid}")

--- a/src/main/java/org/gridsuite/dynamicsecurityanalysis/server/controller/DynamicSecurityAnalysisController.java
+++ b/src/main/java/org/gridsuite/dynamicsecurityanalysis/server/controller/DynamicSecurityAnalysisController.java
@@ -27,7 +27,8 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.gridsuite.computation.service.AbstractResultContext.*;
-import static org.gridsuite.computation.service.NotificationService.*;
+import static org.gridsuite.computation.service.NotificationService.HEADER_RECEIVER;
+import static org.gridsuite.computation.service.NotificationService.HEADER_USER_ID;
 import static org.gridsuite.dynamicsecurityanalysis.server.DynamicSecurityAnalysisApi.API_VERSION;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
@@ -60,7 +61,6 @@ public class DynamicSecurityAnalysisController {
                                           @RequestParam(name = "reportUuid", required = false) UUID reportId,
                                           @RequestParam(name = REPORTER_ID_HEADER, required = false) String reportName,
                                           @RequestParam(name = REPORT_TYPE_HEADER, required = false, defaultValue = "DynamicSecurityAnalysis") String reportType,
-                                          @RequestParam(name = HEADER_PROVIDER, required = false) String provider,
                                           @RequestParam(name = "debug", required = false, defaultValue = "false") boolean debug,
                                           @RequestParam(name = "dynamicSimulationResultUuid") UUID dynamicSimulationResultUuid,
                                           @RequestParam(name = "parametersUuid") UUID parametersUuid,
@@ -70,7 +70,6 @@ public class DynamicSecurityAnalysisController {
             networkUuid,
             variantId,
             receiver,
-            provider,
             ReportInfos.builder().reportUuid(reportId).reporterId(reportName).computationType(reportType).build(),
             userId,
             dynamicSimulationResultUuid,

--- a/src/main/java/org/gridsuite/dynamicsecurityanalysis/server/service/ParametersService.java
+++ b/src/main/java/org/gridsuite/dynamicsecurityanalysis/server/service/ParametersService.java
@@ -68,7 +68,7 @@ public class ParametersService {
 
     @Transactional(readOnly = true)
     public DynamicSecurityAnalysisRunContext createRunContext(UUID networkUuid, String variantId, String receiver,
-                                                              String provider, ReportInfos reportInfos, String userId,
+                                                              ReportInfos reportInfos, String userId,
                                                               UUID dynamicSimulationResultUuid,
                                                               UUID dynamicSecurityAnalysisParametersUuid,
                                                               boolean debug) {
@@ -89,11 +89,7 @@ public class ParametersService {
         runContext.setDynamicSimulationResultUuid(dynamicSimulationResultUuid);
 
         // set provider for run context
-        String providerToUse = provider;
-        if (providerToUse == null) {
-            providerToUse = Optional.ofNullable(runContext.getParameters().getProvider()).orElse(defaultProvider);
-        }
-
+        String providerToUse = Optional.ofNullable(runContext.getParameters().getProvider()).orElse(defaultProvider);
         runContext.setProvider(providerToUse);
 
         // check provider

--- a/src/test/java/org/gridsuite/dynamicsecurityanalysis/server/controller/DynamicSecurityAnalysisControllerTest.java
+++ b/src/test/java/org/gridsuite/dynamicsecurityanalysis/server/controller/DynamicSecurityAnalysisControllerTest.java
@@ -255,10 +255,10 @@ public class DynamicSecurityAnalysisControllerTest extends AbstractDynamicSecuri
 
         assertThat(statusAfterInvalidate).isSameAs(DynamicSecurityAnalysisStatus.NOT_DONE);
 
-        // set NOT_DONE for none existing result
+        // set NOT_DONE for none existing result => 200 (same as delete)
         mockMvc.perform(
                         put("/v1/results/invalidate-status?resultUuid=" + UUID.randomUUID()))
-                .andExpect(status().isNotFound());
+                .andExpect(status().isOk());
 
         //delete a result
         mockMvc.perform(

--- a/src/test/java/org/gridsuite/dynamicsecurityanalysis/server/controller/DynamicSecurityAnalysisControllerTest.java
+++ b/src/test/java/org/gridsuite/dynamicsecurityanalysis/server/controller/DynamicSecurityAnalysisControllerTest.java
@@ -281,13 +281,21 @@ public class DynamicSecurityAnalysisControllerTest extends AbstractDynamicSecuri
 
     @Test
     void testRunWithSynchronousExceptions() throws Exception {
+
+        // mock a fake provider in a parameter
+        DynamicSecurityAnalysisParametersInfos defaultParams = parametersService.getDefaultParametersValues();
+        defaultParams.setProvider("notFoundProvider");
+        DynamicSecurityAnalysisParametersEntity entity = new DynamicSecurityAnalysisParametersEntity(defaultParams);
+        UUID notFoundProviderParametersUuid = UUID.randomUUID();
+        given(dynamicSecurityAnalysisParametersRepository.findById(notFoundProviderParametersUuid)).willReturn(Optional.of(entity));
+
         //run the dynamic security analysis on a non-exiting provider
         mockMvc.perform(
                         post("/v1/networks/{networkUuid}/run", NETWORK_UUID.toString())
                         .param(HEADER_PROVIDER, "notFoundProvider")
                         .param(VARIANT_ID_HEADER, VARIANT_1_ID)
                         .param("dynamicSimulationResultUuid", DYNAMIC_SIMULATION_RESULT_UUID.toString())
-                        .param("parametersUuid", PARAMETERS_UUID.toString())
+                        .param("parametersUuid", notFoundProviderParametersUuid.toString())
                         .contentType(APPLICATION_JSON)
                         .header(HEADER_USER_ID, "testUserId"))
                         .andExpect(status().isNotFound());


### PR DESCRIPTION
## PR Summary
Remove `provider` from run request's params



